### PR TITLE
Fix pip install command in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clone the repository:
 
 ```bash
 git clone https://github.com/s7nfo/Cirron.git
-pip install ./cirron
+pip install ./Cirron
 ```
 
 The Python wrapper automatically compiles the C++ library (cirronlib.cpp) on first use.


### PR DESCRIPTION
Fix example installation command. On Ubuntu it failed after I copied these commands, then I realized it was because the repository name is `Cirron` (capital C). Thanks!